### PR TITLE
Add agent rules starter sample link

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ project/
 
 > 💡 Note: `.cursor/rules/` only loads files with the `.mdc` extension — a plain `.md` placed there is ignored, *except* when it's named `AGENTS.md`.
 
+Starter sample: [Agent Rules Starter Free](https://github.com/758302-tech/agent-rules-starter-free) includes a minimal `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/agent-baseline.mdc` setup that can be copied into a new project.
+
 ## 🚀 Featured Framework Transformations
 
 ### Python Test Automation Evolution


### PR DESCRIPTION
## Summary
- Add a small starter sample link to the AGENTS.md section
- Point readers to a minimal AGENTS.md, CLAUDE.md, and Cursor .mdc setup

## Why
The README explains when to use AGENTS.md vs .cursor/rules/*.mdc. This gives readers a copy-ready example that includes both approaches.

## Validation
- Checked README diff only.