### PR TITLE
feat: FastAPI için modern cursor rule ekle (example-structures)

### DIFF
--- a/example-structures/STRUCTURE-OVERVIEW.md
+++ b/example-structures/STRUCTURE-OVERVIEW.md
@@ -54,6 +54,21 @@ react-typescript/
 - **State Management**: Context API with useReducer patterns
 - **Testing Integration**: Comprehensive testing with Testing Library
 
+### ⚡ FastAPI
+```
+fastapi/
+├── .cursor/rules/
+│   └── api-patterns.mdc              # Routers, schemas, DI, async handlers
+└── app/
+```
+
+**Key Features:**
+- **Project Structure**: Routers, services, schemas, and dependencies separation
+- **Pydantic v2 Schemas**: `from_attributes`, `model_dump(exclude_unset=True)`, typed fields
+- **Dependency Injection**: Reusable `Depends()` callables for auth, DB sessions
+- **Async Patterns**: Async SQLAlchemy, `AsyncSession`, lifespan context manager
+- **Testing**: pytest + httpx `AsyncClient` with `ASGITransport` and dependency overrides
+
 ## 🔄 Migration Benefits
 
 ### Legacy Problems vs Modern Solutions
@@ -127,7 +142,7 @@ globs: **/*.cy.js,**/*.cy.ts,**/cypress/**/*.js
 ## 🎉 Getting Started
 
 ### Quick Setup
-1. **Choose Framework**: Select from Selenium Python, Cypress, or React TypeScript
+1. **Choose Framework**: Select from Selenium Python, Cypress, React TypeScript, or FastAPI
 2. **Copy Rules**: Copy `.mdc` files to your project's `.cursor/rules/` directory
 3. **Customize**: Adjust glob patterns and examples to match your project structure
 4. **Iterate**: Refine rules based on team feedback and project needs

--- a/example-structures/fastapi/.cursor/rules/api-patterns.mdc
+++ b/example-structures/fastapi/.cursor/rules/api-patterns.mdc
@@ -1,0 +1,290 @@
+---
+description: FastAPI modern Python API patterns — routers, Pydantic v2 schemas, dependency injection, async handlers, and error handling
+globs: **/main.py,**/routers/**/*.py,**/schemas/**/*.py,**/dependencies/**/*.py,**/services/**/*.py,**/models/**/*.py
+alwaysApply: false
+---
+# FastAPI Excellence
+
+## Project Structure
+
+```
+app/
+├── main.py                  # App factory, middleware, router registration
+├── routers/
+│   ├── users.py             # /users endpoints
+│   └── items.py             # /items endpoints
+├── schemas/
+│   ├── user.py              # Pydantic request/response models
+│   └── item.py
+├── models/
+│   └── database.py          # SQLAlchemy ORM models
+├── dependencies/
+│   └── auth.py              # Shared Depends() callables
+├── services/
+│   └── user_service.py      # Business logic, decoupled from routes
+└── core/
+    ├── config.py             # Settings via pydantic-settings
+    └── database.py           # Async engine + session factory
+```
+
+## Application Factory
+
+```python
+# app/main.py
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from app.routers import users, items
+from app.core.database import engine, Base
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await engine.begin(run_sync=Base.metadata.create_all)  # startup
+    yield
+    await engine.dispose()  # shutdown
+
+
+app = FastAPI(title="My API", version="1.0.0", lifespan=lifespan)
+
+app.include_router(users.router, prefix="/users", tags=["users"])
+app.include_router(items.router, prefix="/items", tags=["items"])
+```
+
+## Pydantic v2 Schemas
+
+```python
+# app/schemas/user.py
+from datetime import datetime
+from pydantic import BaseModel, EmailStr, Field, ConfigDict
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    name: str = Field(min_length=1, max_length=100)
+    password: str = Field(min_length=8)
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)  # replaces orm_mode
+
+    id: int
+    email: EmailStr
+    name: str
+    created_at: datetime
+
+
+class UserUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=100)
+    email: EmailStr | None = None
+```
+
+## Router Organization
+
+```python
+# app/routers/users.py
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.core.database import get_session
+from app.dependencies.auth import get_current_user
+from app.schemas.user import UserCreate, UserResponse, UserUpdate
+from app.services.user_service import UserService
+
+router = APIRouter()
+
+
+@router.get("/{user_id}", response_model=UserResponse)
+async def get_user(
+    user_id: int,
+    session: AsyncSession = Depends(get_session),
+    _: UserResponse = Depends(get_current_user),
+):
+    user = await UserService(session).get_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return user
+
+
+@router.post("/", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+async def create_user(
+    payload: UserCreate,
+    session: AsyncSession = Depends(get_session),
+):
+    return await UserService(session).create(payload)
+
+
+@router.patch("/{user_id}", response_model=UserResponse)
+async def update_user(
+    user_id: int,
+    payload: UserUpdate,
+    session: AsyncSession = Depends(get_session),
+    current_user: UserResponse = Depends(get_current_user),
+):
+    if current_user.id != user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not allowed")
+    return await UserService(session).update(user_id, payload)
+```
+
+## Dependency Injection
+
+```python
+# app/dependencies/auth.py
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.core.database import get_session
+from app.services.user_service import UserService
+
+bearer = HTTPBearer()
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    session: AsyncSession = Depends(get_session),
+):
+    token = credentials.credentials
+    user_id = verify_jwt(token)  # raises ValueError on invalid token
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    user = await UserService(session).get_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return user
+
+
+# app/core/database.py
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+
+engine = create_async_engine(settings.DATABASE_URL, echo=False)
+SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_session() -> AsyncSession:
+    async with SessionLocal() as session:
+        yield session
+```
+
+## Service Layer
+
+```python
+# app/services/user_service.py
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.database import User
+from app.schemas.user import UserCreate, UserUpdate
+
+
+class UserService:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_by_id(self, user_id: int) -> User | None:
+        result = await self.session.execute(select(User).where(User.id == user_id))
+        return result.scalar_one_or_none()
+
+    async def create(self, payload: UserCreate) -> User:
+        user = User(
+            email=payload.email,
+            name=payload.name,
+            hashed_password=hash_password(payload.password),
+        )
+        self.session.add(user)
+        await self.session.commit()
+        await self.session.refresh(user)
+        return user
+
+    async def update(self, user_id: int, payload: UserUpdate) -> User:
+        user = await self.get_by_id(user_id)
+        update_data = payload.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(user, field, value)
+        await self.session.commit()
+        await self.session.refresh(user)
+        return user
+```
+
+## Settings with pydantic-settings
+
+```python
+# app/core/config.py
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+    DATABASE_URL: str
+    SECRET_KEY: str
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    ENVIRONMENT: str = "development"
+
+    @property
+    def is_production(self) -> bool:
+        return self.ENVIRONMENT == "production"
+
+
+settings = Settings()
+```
+
+## Testing with pytest + httpx
+
+```python
+# tests/conftest.py
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from app.main import app
+from app.core.database import get_session, Base
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+@pytest.fixture(scope="session")
+async def engine():
+    engine = create_async_engine(TEST_DATABASE_URL)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+@pytest.fixture
+async def session(engine):
+    TestSession = async_sessionmaker(engine, expire_on_commit=False)
+    async with TestSession() as s:
+        yield s
+
+@pytest.fixture
+async def client(session: AsyncSession):
+    app.dependency_overrides[get_session] = lambda: session
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+# tests/test_users.py
+import pytest
+
+@pytest.mark.anyio
+async def test_create_user(client):
+    response = await client.post("/users/", json={
+        "email": "test@example.com",
+        "name": "Test User",
+        "password": "securepass123",
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == "test@example.com"
+    assert "id" in data
+```
+
+## Key Rules
+
+- Always use `async def` for route handlers; reserve `def` only for synchronous CPU-bound tasks run via `run_in_executor`
+- Keep business logic in the service layer — routes should only validate, delegate, and respond
+- Use `model_dump(exclude_unset=True)` for PATCH payloads to avoid overwriting fields with `None`
+- Prefer `status.HTTP_*` constants over raw integers for readability and IDE support
+- Never expose internal exceptions directly — map them to `HTTPException` at the router boundary
+- Use `response_model=` to explicitly control serialization; omit sensitive fields (passwords, tokens) from response schemas
+- Pin `anyio` backend in `pytest.ini`: `asyncio_mode = auto` with `anyio` for async test fixtures


### PR DESCRIPTION
## Ne eklendi?

`example-structures/fastapi/.cursor/rules/api-patterns.mdc` — FastAPI projeleri için modern, context-aware bir Cursor Rules dosyası.

## Kapsanan konular

- **Proje yapısı**: `routers/`, `schemas/`, `services/`, `dependencies/`, `core/` ayrımı
- **Pydantic v2 şemaları**: `from_attributes` (orm_mode yerine), `model_dump(exclude_unset=True)`, `EmailStr`, `Field` validasyonları
- **APIRouter organizasyonu**: prefix, tags, HTTP durum sabitleri (`status.HTTP_*`)
- **Dependency Injection**: `Depends()` ile paylaşımlı DB oturumu ve kimlik doğrulama
- **Async SQLAlchemy**: `AsyncSession`, `async_sessionmaker`, lifespan context manager
- **Service layer**: İş mantığını router'dan ayıran sınıf bazlı servis deseni
- **pydantic-settings**: `.env` tabanlı `Settings` yönetimi
- **Test**: `pytest` + `httpx.AsyncClient` + `ASGITransport` + dependency override örneği
- **Key rules**: `async def`, `response_model`, `exclude_unset`, hata yönetimi kuralları

## Güncellenen dosyalar

- `example-structures/STRUCTURE-OVERVIEW.md` — FastAPI bölümü ve "Getting Started" listesi eklendi

## Neden FastAPI?

Mevcut `example-structures/` klasörü Next.js, React TypeScript, Cypress ve Selenium Python'u kapsıyor; Python backend için hiç örnek yoktu. FastAPI, Python ekosisteminin en popüler async web framework'ü olup özellikle LLM/AI backend uygulamalarında yaygın kullanılıyor. Eklenen kural dosyası diğer `.mdc` örnekleriyle birebir aynı formatı izliyor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FjMtLSYRRfkzyvHmq7hLMQ)_